### PR TITLE
fix: add unstorage as an optional peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The best persistence plugin for pinia.
 pnpm add pinia-plugin-unstorage
 ```
 
+With no options specified, `pinia-plugin-unstorage` uses the browser's local storage as the driver by default. To use a different driver, install the optional peer dependency:
+
+```bash
+pnpm add pinia-plugin-unstorage unstorage
+```
+
 ## Usage
 
 ### Vue app

--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
     },
     "peerDependencies": {
         "pinia": "3",
+        "unstorage": "1",
         "vue": "3"
+    },
+    "peerDependenciesMeta": {
+        "unstorage": true
     },
     "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
     "build": {


### PR DESCRIPTION
# Reasoning

For pnpm compatibility, adding `unstorage` in `peerDependencies` matching the major version listed in `dependencies` allows users to install `unstorage` that is kept at the same versioning that `pinia-plugin-unstorage` uses.

Not having this in peerDependencies opens up the possibility of version drifting. Setting `peerDependenciesMeta.unstorage` to `true` makes having unstorage intalled optional. This keeps pnpm from throwing warnings or errors if unstorage is not installed.

Updated documentation outlining this peer dependency if a driver other than localStorage is needed by the user.

## Misc

If this is not needed or wanted, my apologies. Thank you for your time in reading this.